### PR TITLE
Update how Github PR Contributor XP is awarded

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ These actions are tracked and logged by bots, reviewed by humans weekly, and the
 #### Contributor XP
 
 - Author a pull request that is merged (start in #dev on Discord)
+- XP is awarded with exponential backoff with powers of 2. I.E. a user is awarded 1 Contributor XP for every 1st, 2nd, 4th, 8th, 16th, 32nd PR, etc.
 </div>
 
 <div class="content-community">


### PR DESCRIPTION
This PR proposes that we award contributor XP from merged Github PRs with an exponential backoff algorithm. The reason for this proposition is that stats would be very inflated with the current method of awarding 1 XP per PR. The exponential backoff algorithm is currently what we use when awarding Community XP for community call attendance, so I think it would be consistent and make sense to apply the same for Github PRs + Contributor XP.

The algorithm would award 1 XP for every power of 2 PR completed, i.e. 1st, 2nd, 4th, 8th, 16th, etc.