### PR TITLE
Proposal for Papr Hero Community NFT Rewards

### DIFF
--- a/misc/Papr_Hero_XP_2022.md
+++ b/misc/Papr_Hero_XP_2022.md
@@ -1,0 +1,5 @@
+This doc briefly highlights how we will award XP to those who participated in Papr Hero. 
+As a reminder, Papr Hero was a testnet competition to see who could accumulate the most phUSDC using the papr protocol on Goerli.
+
+Our proposal is to award each participant in the competition `1 Community XP` and `1 Activity XP`. Additionally, we plan to award the winner of the competition 
+a special bunny accessory for their community NFT.


### PR DESCRIPTION
The doc this PR introduces briefly highlights how we will award XP to those who participated in Papr Hero.  As a reminder, Papr Hero was a testnet competition to see who could accumulate the most phUSDC using the papr protocol on Goerli.

Our proposal is to award each participant in the competition `1 Community XP` and `1 Activity XP`. Additionally, we plan to award the winner of the competition a special bunny accessory for their community NFT.